### PR TITLE
Fix plots in EDFigure7

### DIFF
--- a/figures/ExtendedDataFigure7.ipynb
+++ b/figures/ExtendedDataFigure7.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3943ceae",
+   "id": "3335f84b",
    "metadata": {},
    "source": [
     "# Extended Data Figure 7: Multi-session training and rapid decoding"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f862f63",
+   "id": "d331471f",
    "metadata": {},
    "source": [
     "#### import plot and data loading dependencies"
@@ -19,13 +19,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9bdfd599",
+   "id": "4ae23392",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:07.915258Z",
-     "iopub.status.busy": "2022-10-11T00:55:07.914900Z",
-     "iopub.status.idle": "2022-10-11T00:55:11.683434Z",
-     "shell.execute_reply": "2022-10-11T00:55:11.682189Z"
+     "iopub.execute_input": "2022-11-03T23:50:06.255340Z",
+     "iopub.status.busy": "2022-11-03T23:50:06.254867Z",
+     "iopub.status.idle": "2022-11-03T23:50:07.571065Z",
+     "shell.execute_reply": "2022-11-03T23:50:07.570398Z"
     }
    },
    "outputs": [],
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ba3c63e",
+   "id": "e0474aa0",
    "metadata": {},
    "source": [
     "#### Define data loading & functions"
@@ -53,13 +53,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "cac1b426",
+   "id": "026ca063",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:11.695630Z",
-     "iopub.status.busy": "2022-10-11T00:55:11.693046Z",
-     "iopub.status.idle": "2022-10-11T00:55:11.711285Z",
-     "shell.execute_reply": "2022-10-11T00:55:11.710003Z"
+     "iopub.execute_input": "2022-11-03T23:50:07.574765Z",
+     "iopub.status.busy": "2022-11-03T23:50:07.574177Z",
+     "iopub.status.idle": "2022-11-03T23:50:07.578899Z",
+     "shell.execute_reply": "2022-11-03T23:50:07.578479Z"
     },
     "lines_to_end_of_cell_marker": 2,
     "lines_to_next_cell": 2
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "792fceee",
+   "id": "d6f1ae3c",
    "metadata": {},
    "source": [
     "#### Define metric functions"
@@ -91,13 +91,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "60da028a",
+   "id": "c0446fad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:11.724006Z",
-     "iopub.status.busy": "2022-10-11T00:55:11.723298Z",
-     "iopub.status.idle": "2022-10-11T00:55:18.869507Z",
-     "shell.execute_reply": "2022-10-11T00:55:18.868192Z"
+     "iopub.execute_input": "2022-11-03T23:50:07.583804Z",
+     "iopub.status.busy": "2022-11-03T23:50:07.583413Z",
+     "iopub.status.idle": "2022-11-03T23:50:09.620476Z",
+     "shell.execute_reply": "2022-11-03T23:50:09.619786Z"
     }
    },
    "outputs": [
@@ -105,7 +105,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_299505/2666736443.py:12: PerformanceWarning: indexing past lexsort depth may impact performance.\n",
+      "/tmp/ipykernel_852782/2666736443.py:12: PerformanceWarning: indexing past lexsort depth may impact performance.\n",
       "  sorted_results.loc[i, \"seed\"] = np.arange(10)\n"
      ]
     }
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43511def",
+   "id": "a9ae75f6",
    "metadata": {},
    "source": [
     "#### Load and check metrics"
@@ -175,13 +175,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "fbfed61f",
+   "id": "d42875f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:18.875896Z",
-     "iopub.status.busy": "2022-10-11T00:55:18.875510Z",
-     "iopub.status.idle": "2022-10-11T00:55:20.049350Z",
-     "shell.execute_reply": "2022-10-11T00:55:20.048236Z"
+     "iopub.execute_input": "2022-11-03T23:50:09.625885Z",
+     "iopub.status.busy": "2022-11-03T23:50:09.625526Z",
+     "iopub.status.idle": "2022-11-03T23:50:09.993800Z",
+     "shell.execute_reply": "2022-11-03T23:50:09.993133Z"
     }
    },
    "outputs": [
@@ -189,7 +189,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_299505/495670736.py:2: FutureWarning: Dropping invalid columns in DataFrameGroupBy.agg is deprecated. In a future version, a TypeError will be raised. Before calling .agg, select only columns which should be valid for the function.\n",
+      "/tmp/ipykernel_852782/495670736.py:2: FutureWarning: Dropping invalid columns in DataFrameGroupBy.agg is deprecated. In a future version, a TypeError will be raised. Before calling .agg, select only columns which should be valid for the function.\n",
       "  aggregated_results = sorted_results.groupby(aggregated_metrics).agg(mean).reset_index()\n"
      ]
     }
@@ -215,13 +215,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "79b81440",
+   "id": "08226209",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:20.055187Z",
-     "iopub.status.busy": "2022-10-11T00:55:20.054576Z",
-     "iopub.status.idle": "2022-10-11T00:55:20.392946Z",
-     "shell.execute_reply": "2022-10-11T00:55:20.391622Z"
+     "iopub.execute_input": "2022-11-03T23:50:09.998590Z",
+     "iopub.status.busy": "2022-11-03T23:50:09.998230Z",
+     "iopub.status.idle": "2022-11-03T23:50:10.143032Z",
+     "shell.execute_reply": "2022-11-03T23:50:10.142357Z"
     }
    },
    "outputs": [],
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33bebd8f",
+   "id": "f2a4c945",
    "metadata": {},
    "source": [
     "### Comparison of decoding vs. consistency\n",
@@ -272,13 +272,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "821fa42b",
+   "id": "780c7291",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:20.398982Z",
-     "iopub.status.busy": "2022-10-11T00:55:20.398583Z",
-     "iopub.status.idle": "2022-10-11T00:55:26.279136Z",
-     "shell.execute_reply": "2022-10-11T00:55:26.277886Z"
+     "iopub.execute_input": "2022-11-03T23:50:10.148163Z",
+     "iopub.status.busy": "2022-11-03T23:50:10.147997Z",
+     "iopub.status.idle": "2022-11-03T23:50:11.999419Z",
+     "shell.execute_reply": "2022-11-03T23:50:11.998540Z"
     }
    },
    "outputs": [
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afdaa54a",
+   "id": "ccb75a32",
    "metadata": {},
    "source": [
     "### consistency matrix single vs. multi-session training for hippocampus (32D embedding) and Allen data (128D embedding) respectively.\n",
@@ -422,13 +422,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a9fa0c21",
+   "id": "9ba98a38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:26.310349Z",
-     "iopub.status.busy": "2022-10-11T00:55:26.309860Z",
-     "iopub.status.idle": "2022-10-11T00:55:26.784480Z",
-     "shell.execute_reply": "2022-10-11T00:55:26.783445Z"
+     "iopub.execute_input": "2022-11-03T23:50:12.003323Z",
+     "iopub.status.busy": "2022-11-03T23:50:12.003051Z",
+     "iopub.status.idle": "2022-11-03T23:50:12.180414Z",
+     "shell.execute_reply": "2022-11-03T23:50:12.179713Z"
     }
    },
    "outputs": [
@@ -525,13 +525,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "f0cfeb81",
+   "id": "7a8f7c38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:26.790629Z",
-     "iopub.status.busy": "2022-10-11T00:55:26.790259Z",
-     "iopub.status.idle": "2022-10-11T00:55:28.064631Z",
-     "shell.execute_reply": "2022-10-11T00:55:28.063545Z"
+     "iopub.execute_input": "2022-11-03T23:50:12.213665Z",
+     "iopub.status.busy": "2022-11-03T23:50:12.213334Z",
+     "iopub.status.idle": "2022-11-03T23:50:12.813243Z",
+     "shell.execute_reply": "2022-11-03T23:50:12.812561Z"
     }
    },
    "outputs": [
@@ -539,10 +539,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_299505/1272793558.py:20: FutureWarning: Dropping invalid columns in DataFrameGroupBy.agg is deprecated. In a future version, a TypeError will be raised. Before calling .agg, select only columns which should be valid for the function.\n",
-      "  results.groupby([c for c in metrics + [\"data_mode\"] if c != \"repeat\"])\n",
-      "/tmp/ipykernel_299505/1272793558.py:24: UserWarning: Boolean Series key will be reindexed to match DataFrame index.\n",
-      "  filtered_results = results_[\n"
+      "/tmp/ipykernel_852782/1272793558.py:20: FutureWarning: Dropping invalid columns in DataFrameGroupBy.agg is deprecated. In a future version, a TypeError will be raised. Before calling .agg, select only columns which should be valid for the function.\n",
+      "  results.groupby([c for c in metrics + [\"data_mode\"] if c != \"repeat\"])\n"
      ]
     },
     {
@@ -550,6 +548,14 @@
      "output_type": "stream",
      "text": [
       "Allen dataset\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_852782/1272793558.py:24: UserWarning: Boolean Series key will be reindexed to match DataFrame index.\n",
+      "  filtered_results = results_[\n"
      ]
     },
     {
@@ -640,13 +646,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "8279196f",
+   "id": "ef938db2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:28.070426Z",
-     "iopub.status.busy": "2022-10-11T00:55:28.069584Z",
-     "iopub.status.idle": "2022-10-11T00:55:28.078124Z",
-     "shell.execute_reply": "2022-10-11T00:55:28.077001Z"
+     "iopub.execute_input": "2022-11-03T23:50:12.816957Z",
+     "iopub.status.busy": "2022-11-03T23:50:12.816758Z",
+     "iopub.status.idle": "2022-11-03T23:50:12.821761Z",
+     "shell.execute_reply": "2022-11-03T23:50:12.821171Z"
     }
    },
    "outputs": [
@@ -674,7 +680,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13d7c258",
+   "id": "314522cc",
    "metadata": {},
    "source": [
     "#### Statistics"
@@ -683,13 +689,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "3c08e752",
+   "id": "8f59e55f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:28.083854Z",
-     "iopub.status.busy": "2022-10-11T00:55:28.083102Z",
-     "iopub.status.idle": "2022-10-11T00:55:28.091900Z",
-     "shell.execute_reply": "2022-10-11T00:55:28.090907Z"
+     "iopub.execute_input": "2022-11-03T23:50:12.825687Z",
+     "iopub.status.busy": "2022-11-03T23:50:12.825398Z",
+     "iopub.status.idle": "2022-11-03T23:50:12.841018Z",
+     "shell.execute_reply": "2022-11-03T23:50:12.840433Z"
     }
    },
    "outputs": [
@@ -716,7 +722,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8f21553",
+   "id": "fcddf91d",
    "metadata": {},
    "source": [
     "#### Accuracy on train, validation, and test sets:"
@@ -725,28 +731,16 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "9d2ed770",
+   "id": "2030c856",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:28.097250Z",
-     "iopub.status.busy": "2022-10-11T00:55:28.096610Z",
-     "iopub.status.idle": "2022-10-11T00:55:28.247212Z",
-     "shell.execute_reply": "2022-10-11T00:55:28.246330Z"
+     "iopub.execute_input": "2022-11-03T23:50:12.844744Z",
+     "iopub.status.busy": "2022-11-03T23:50:12.844436Z",
+     "iopub.status.idle": "2022-11-03T23:50:12.931247Z",
+     "shell.execute_reply": "2022-11-03T23:50:12.930358Z"
     }
    },
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style>.container { width:100% !important; }</style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "data": {
       "text/html": [
@@ -996,8 +990,6 @@
     "        for key in keys\n",
     "    )\n",
     "\n",
-    "    display(HTML(\"<style>.container { width:100% !important; }</style>\"))\n",
-    "\n",
     "    titles = [\n",
     "        \"Consistency (R², train)\",\n",
     "        \"Consistency (R², valid)\",\n",
@@ -1027,7 +1019,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c486c80",
+   "id": "b07b45a5",
    "metadata": {},
    "source": [
     "### Load data for Fine-tuning on unseen subject experiments, and define plotting code"
@@ -1036,13 +1028,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "867cdebe",
+   "id": "370fe0aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:28.252041Z",
-     "iopub.status.busy": "2022-10-11T00:55:28.251652Z",
-     "iopub.status.idle": "2022-10-11T00:55:28.270026Z",
-     "shell.execute_reply": "2022-10-11T00:55:28.269132Z"
+     "iopub.execute_input": "2022-11-03T23:50:12.936665Z",
+     "iopub.status.busy": "2022-11-03T23:50:12.936361Z",
+     "iopub.status.idle": "2022-11-03T23:50:12.952423Z",
+     "shell.execute_reply": "2022-11-03T23:50:12.951877Z"
     }
    },
    "outputs": [],
@@ -1053,13 +1045,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "0612456d",
+   "id": "491d44cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:28.274520Z",
-     "iopub.status.busy": "2022-10-11T00:55:28.273995Z",
-     "iopub.status.idle": "2022-10-11T00:55:28.285742Z",
-     "shell.execute_reply": "2022-10-11T00:55:28.284791Z"
+     "iopub.execute_input": "2022-11-03T23:50:12.955237Z",
+     "iopub.status.busy": "2022-11-03T23:50:12.954743Z",
+     "iopub.status.idle": "2022-11-03T23:50:12.963569Z",
+     "shell.execute_reply": "2022-11-03T23:50:12.962874Z"
     }
    },
    "outputs": [],
@@ -1134,7 +1126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a199176",
+   "id": "a193502b",
    "metadata": {},
    "source": [
     "### Adapt to an unseen dataset\n",
@@ -1145,13 +1137,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "08a39b73",
+   "id": "31cf1bc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:28.291352Z",
-     "iopub.status.busy": "2022-10-11T00:55:28.290242Z",
-     "iopub.status.idle": "2022-10-11T00:55:28.675601Z",
-     "shell.execute_reply": "2022-10-11T00:55:28.674372Z"
+     "iopub.execute_input": "2022-11-03T23:50:12.966705Z",
+     "iopub.status.busy": "2022-11-03T23:50:12.966444Z",
+     "iopub.status.idle": "2022-11-03T23:50:13.133172Z",
+     "shell.execute_reply": "2022-11-03T23:50:13.132464Z"
     }
    },
    "outputs": [
@@ -1175,7 +1167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fe7465e",
+   "id": "924071a7",
    "metadata": {},
    "source": [
     "### panel, inset"
@@ -1184,13 +1176,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "ffe29312",
+   "id": "55081f91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-10-11T00:55:28.681921Z",
-     "iopub.status.busy": "2022-10-11T00:55:28.681232Z",
-     "iopub.status.idle": "2022-10-11T00:55:28.901372Z",
-     "shell.execute_reply": "2022-10-11T00:55:28.900535Z"
+     "iopub.execute_input": "2022-11-03T23:50:13.137591Z",
+     "iopub.status.busy": "2022-11-03T23:50:13.137320Z",
+     "iopub.status.idle": "2022-11-03T23:50:13.254516Z",
+     "shell.execute_reply": "2022-11-03T23:50:13.253738Z"
     }
    },
    "outputs": [

--- a/src/ExtendedDataFigure7.py
+++ b/src/ExtendedDataFigure7.py
@@ -472,8 +472,6 @@ def show_results(select_by="valid_accuracy", func=np.argmax, keys=KEYS):
         for key in keys
     )
 
-    display(HTML("<style>.container { width:100% !important; }</style>"))
-
     titles = [
         "Consistency (R², train)",
         "Consistency (R², valid)",


### PR DESCRIPTION
Right now the plots are hidden in cebra.ai/docs:

![image](https://user-images.githubusercontent.com/727984/199856106-37358cc8-e5be-4a5a-aade-e00dcd8ff5f7.png)

This is because the notebook is rescaled to have 100% width. This PR fixes this by removing the statement.